### PR TITLE
Change text from a'alinhado' to 'posicionado'

### DIFF
--- a/responses/step-1.md
+++ b/responses/step-1.md
@@ -138,7 +138,7 @@ Para posicioná-lo ao centro, podemos adicionar `textPosition` [(*Choose in whic
 
 ## Atividade
 
-Defina um `rich-text` na sua home e crie um texto "Hello, World!" em *itálico* e **alinhado a direita**. 
+Defina um `rich-text` na sua home e crie um texto "Hello, World!" em *itálico* e **posicionado à direita**. 
 
 <img src="https://user-images.githubusercontent.com/18701182/68888503-d77ae400-06f9-11ea-967b-662fe1dac644.png" width="150" />
 


### PR DESCRIPTION
Since we have props for `textAlignment` and `textPosition` I think it is better to use the word 'posicionado'.